### PR TITLE
Update f_loadout_sog_west_usarmy.sqf

### DIFF
--- a/scripts/GEAR/SOG/f_loadout_sog_west_usarmy.sqf
+++ b/scripts/GEAR/SOG/f_loadout_sog_west_usarmy.sqf
@@ -87,7 +87,7 @@ _glflare = "vn_40mm_m583_flare_w_mag";
 _glflarealt = "vn_40mm_m661_flare_g_mag";
 
 // Pistols (CO, DC, Automatic Rifleman, Medium MG Gunner)
-_pistol = "vn_mx991_m1911";
+_pistol = ["vn_m1911","vn_mx991_m1911"];
 _pistolmag = "vn_m1911_mag";
 
 // Grenades
@@ -328,15 +328,14 @@ switch (_typeOfUnit) do
 	case "ftl":
 	{
 		["g"] call _backpack;
-		_unit addMagazines [_glriflemag,_defMags];
-		_unit addMagazines [_glriflemag_tr,_defMags_tr];
-		_unit addMagazines [_glmag,3];
-		[_unit, _glrifle] call f_fnc_addWeapon;
+		_unit addMagazines [_glmag,24];
+		_unit addMagazines ["vn_40mm_m433_hedp_mag",6];
+		[_unit, "vn_m79"] call f_fnc_addWeapon;
 		_unit addMagazines [_grenade,1];
-		_pistol = "vn_m79_p";
-		_pistolmag = "vn_40mm_m381_he_mag";
+		_pistol = ["vn_m1911","vn_mx991_m1911"];
+		_pistolmag = "vn_m1911_mag";
 		[_unit, _pistol] call f_fnc_addWeapon;
-		_unit addMagazines [_pistolmag,4];
+		_unit addMagazines [_pistolmag,6];
 		[_unit, _binos1] call f_fnc_addWeapon;
 		_attachments = _attach_fl;
 	};


### PR DESCRIPTION
FTLs will now have regular M79 Thumper instead of M16 as primary and M1911/M1911&flashlight as secondary instead of sawn-off M79. Ammo has also been adjusted. I think this change is better both for realism and gameplay. Only slight niggle is the backpack script will still provide a few M16 mags but could just consider that extra ammo to share within the squad.