### PR TITLE
Update parameters.hpp to reduce default respawn timer

### DIFF
--- a/mission/parameters.hpp
+++ b/mission/parameters.hpp
@@ -73,7 +73,7 @@ class f_param_respawn
 	title = "Respawn";
 	values[] = {0,30,60,300,600,900,1200,1,2,5,10};
 	texts[] = {"Disabled","Timer 30 Seconds","Timer 1 Minute","Wave 5 Minutes","Wave 10 Minutes","Wave 15 Minutes","Wave 20 Minutes","2 Tickets","3 Tickets","5 Tickets","10 Tickets"};
-	default = 600;
+	default = 300;
 };
 class f_param_medical
 {


### PR DESCRIPTION
Current default value means players have to wait 10 to 20 minutes to respawn (if not body-bagged) which is a little extreme. I suggest reduce default value to 5 minute wave respawn (i.e. players wait 5 to 10 minutes to respawn).